### PR TITLE
feat: add macOS-style hover selection and auto-switch on key release

### DIFF
--- a/code/ui/main.qml
+++ b/code/ui/main.qml
@@ -69,15 +69,20 @@ KWin.TabBoxSwitcher {
                         source: model.icon
                         // active: index == icons.currentIndex
 
+                        // macOS-style: select on mouse hover
+                        HoverHandler {
+                            onHoveredChanged: {
+                                if (hovered) {
+                                    icons.currentIndex = index;
+                                }
+                            }
+                        }
+
+                        // Click to activate directly
                         TapHandler {
                             onSingleTapped: {
-                                if (index === icons.currentIndex) {
-                                    icons.model.activate(index);
-                                    return;
-                                }
-                                icons.currentIndex = index;
+                                icons.model.activate(index);
                             }
-                            onDoubleTapped: icons.model.activate(index)
                         }
                     }
 


### PR DESCRIPTION
- Add HoverHandler to select applications on mouse hover
- Simplify click behavior to direct activation
- Enable seamless window switching with Alt+Tab release
- Matches macOS window switcher interaction model